### PR TITLE
Add asset pipeline code snippet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ ATTRIBUTE_TYPES = {
   bar: Field::Trix
 }.freeze
 ```
+
+If you're using the Rails asset pipeline, add the following to `app/assets/config/manifest.js`:
+
+```js
+//= link administrate-field-trix/application.css
+//= link administrate-field-trix/application.js
+```


### PR DESCRIPTION
Added a quick note to the README about including `administrate-field-trix` from your Rails asset pipeline manifest. This wasn't documented anywhere and we ran in to issues pretty quick after following the existing documentation.