### PR TITLE
Fix Uncaught TypeError: Cannot read properties of undefined (reading 'Promise')

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # administrate-field-trix
 > A plugin to use the [Trix](https://trix-editor.org) WYSIWYG editor within in [Administrate](https://github.com/thoughtbot/administrate).
 
-**Forked from [https://github.com/ianwalter/administrate-field-trix](https://github.com/ianwalter/administrate-field-trix)**
+**Forked from [headwayio/administrate-field-trix](https://github.com/headwayio/administrate-field-trix)**
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # administrate-field-trix
 > A plugin to use the [Trix](https://trix-editor.org) WYSIWYG editor within in [Administrate](https://github.com/thoughtbot/administrate).
 
-**Forked from [headwayio/administrate-field-trix](https://github.com/headwayio/administrate-field-trix)**
+**Forked from [https://github.com/ianwalter/administrate-field-trix](https://github.com/ianwalter/administrate-field-trix)**
 
 ## Install
 
@@ -9,7 +9,6 @@ Add [trix-rails](https://github.com/kylefox/trix/) and `administrate-field-trix`
 to your `Gemfile`:
 
 ```ruby
-gem 'trix-rails', require: 'trix'
 gem 'administrate-field-trix'
 ```
 

--- a/app/views/fields/trix/_form.html.erb
+++ b/app/views/fields/trix/_form.html.erb
@@ -2,5 +2,5 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.trix_editor field.attribute %>
+  <%= f.rich_text_area field.attribute %>
 </div>


### PR DESCRIPTION
Fix: Uncaught TypeError: Cannot read properties of undefined (reading 'Promise')
by removing trix-rails from Gemfile (as explained in https://github.com/basecamp/trix/issues/954) and use rich_text_area instead of trix_editor


